### PR TITLE
Rebuild site: modern SPA that runs ML in the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,26 @@
-# Deep Learning RTP recommends
+# deeplearningrtp.github.io
 
-## Study Groups
+The website for the **[Deep Learning RTP](https://www.meetup.com/deep-learning-rtp/)** study
+group — live at **https://deeplearningrtp.github.io/**.
 
-**Monday**       6pm - 8pm at Dulce Dessert Cafe, Fayetteville Rd, Durham
+A single static `index.html`: modern SPA, no build step, no framework, no backend. Its centerpiece
+is machine learning running **entirely in the visitor's browser** (fitting for a deep-learning group):
 
-**Thursday**   noon - 2pm at The Frontier in RTP 
+- **Sentiment analysis** & **image classification** via [Transformers.js](https://huggingface.co/docs/transformers.js) (WASM/WebGPU — works in every browser).
+- **Local LLM chat** via [WebLLM](https://webllm.mlc.ai/) (WebGPU — Chrome/Edge/Safari 26+).
 
-**Sunday**      10am - 1pm at HQ Raleigh
+Libraries are lazy-imported from CDN only when a demo is clicked, so the page itself loads instantly
+and no model weights download until a visitor opts in. Nothing is ever sent to a server.
 
-**Computer Vision** [Triangle Computer Vision and Image Processing Group](https://www.meetup.com/Triangle-Computer-Vision-and-Image-Processing-Group/)
+## Run locally
+```bash
+python3 -m http.server 8000   # then open http://localhost:8000
+```
+(Any static server works — the demos need `https://` or `localhost` for WebGPU.)
 
+## Deploy
+GitHub Pages serves the `master` branch as-is (`.nojekyll` disables Jekyll). Merge to `master` → live.
 
-## Learning Resources
-
-Recent history of deep learning from the fantastic podcast [Talking Machines](url=http://www.thetalkingmachines.com/blog/)
-- History of Deep Learning from the Inside Out - [Part 1](http://www.thetalkingmachines.com/blog/2015/2/26/the-history-of-machine-learning-from-the-inside-out) and [Part 2](http://www.thetalkingmachines.com/blog/2015/3/13/how-machine-learning-got-where-it-is-and-the-future-of-the-field)
-
-#### Resources we've used in this study group:
-- Start with [Practical Deep Learning for Coders](http://course.fast.ai/) from [fast.ai](http://course.fast.ai)
-- or [deeplearning.ai](https://www.deeplearning.ai/) from Andrew Ng
-- [Neural Networks and Deep Learning](http://neuralnetworksanddeeplearning.com/) from Michael Nielsen
-- [Hands-on Machine Learning with Scikit-Learn & Tensorflow](http://shop.oreilly.com/product/0636920052289.do) by Aurelien Geron
-
-#### Courses worth looking into:
-- [Deep Natural Language Processing from Oxford](https://github.com/oxford-cs-deepnlp-2017/lectures) 
-- [CS231n Convolutional Neural Networks for Visual Image Recognition](https://cs231n.github.io/)
-- [Numerical Linear Algebra](https://github.com/fastai/numerical-linear-algebra) from fast.ai
-- [Machine Learning for Artists](https://ml4a.github.io/)
-
-#### Down the Deep Rabbit Hole
-- [The Elements of Statistical Learning: Data Mining, Inference, and Prediction.](https://web.stanford.edu/~hastie/ElemStatLearn/)
-- [Deep Learning Book](http://www.deeplearningbook.org/)
-
-#### To Infinity and Beyond:
-As the number of deep learning tutorials and lists of lists approaches infinity, here are some good places to browse -
-- [Awesome Deep Learning](https://github.com/ChristosChristofidis/awesome-deep-learning)
-- and [Arxiv Sanity Preserver](http://www.arxiv-sanity.com/)
-
-#### Our projects so far (July 16, 2017):
-- [Tensorflow talks](https://github.com/apiltamang/tensorflow_rtp_materials)
-- [Apil speaks](https://youtu.be/R13oMsL_7hY) at PyData
-- DonkeyCar!
-
-
------------------------------------------
-
-Disclaimer & Code of Conduct:
-
-Deep Learning RTP Meetup is a fully open source, public forum. No expectation of privacy or secrecy regarding content or discussion either in person, in writing, or electronically should be assumed. Please refrain from including or sharing confidential material including, but not limited to, proprietary content, trade secrets, and classified or sensitive material.
-
-Deep Learning Meetup is not liable for the content and/or discussion presented or shared in any form by individual members, visitors, or speakers. This disclaimer extends to all forms of Deep Learning Meetup’s events, discussion, and media- including, but not limited to, chat clients, digital work spaces and storage, and group discussion or collaborative projects.
-
-DL RTP really likes the [Recurse Center Rules](https://www.recurse.com/code-of-conduct). If a participant engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expelling them from the class/event/meetup group.
-
-Feel free to contact any of the DL Meetup Co-organizers with feedback or questions. Thank you for helping to ensure a healthy and friendly environment for all!
-
-----------------------------------------------------------------
-
+## Edit
+Everything is in `index.html` — content, inline CSS, and one `<script type="module">`. The upcoming-events
+list and the two `// ponytail:`-marked model ids are the bits most likely to need updating.

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-tactile

--- a/index.html
+++ b/index.html
@@ -1,0 +1,422 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Deep Learning RTP — a study group that builds neural networks</title>
+<meta name="description" content="Deep Learning RTP: a 1,500+ member study group in the Research Triangle. Weekly paper reviews and deep dives. Try ML models running entirely in your browser.">
+<meta property="og:title" content="Deep Learning RTP">
+<meta property="og:description" content="Weekly neural-network paper reviews & deep dives in RTP. Run ML models in your browser — no server, no API keys.">
+<meta property="og:type" content="website">
+<style>
+  :root{
+    --bg:#07090f; --bg-soft:#0d1119; --card:#111624; --card-2:#161d2e;
+    --text:#e8ecf5; --muted:#9aa6bd; --line:#222b40;
+    --accent:#5eead4; --accent-2:#818cf8; --accent-3:#f472b6;
+    --pos:#34d399; --neg:#fb7185;
+    --grad:linear-gradient(120deg,#5eead4,#818cf8 55%,#f472b6);
+    --shadow:0 10px 40px -12px rgba(0,0,0,.6);
+    --radius:16px;
+  }
+  :root[data-theme="light"]{
+    --bg:#f7f8fc; --bg-soft:#eef1f8; --card:#ffffff; --card-2:#f3f5fb;
+    --text:#141a26; --muted:#586178; --line:#e2e6f0;
+    --accent:#0d9488; --accent-2:#4f46e5; --accent-3:#db2777;
+    --shadow:0 10px 40px -18px rgba(20,26,38,.25);
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  @media (prefers-reduced-motion:reduce){html{scroll-behavior:auto} *{animation:none!important;transition:none!important}}
+  body{
+    margin:0;background:var(--bg);color:var(--text);
+    font:16px/1.6 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased;overflow-x:hidden;
+  }
+  code,kbd,.mono{font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace}
+  a{color:var(--accent);text-decoration:none}
+  a:hover{text-decoration:underline}
+  h1,h2,h3{line-height:1.15;letter-spacing:-.02em;margin:0 0 .4em}
+  .wrap{max-width:1040px;margin:0 auto;padding:0 20px}
+  section{padding:72px 0;border-top:1px solid var(--line)}
+  .eyebrow{font:600 12px/1 ui-monospace,monospace;letter-spacing:.22em;text-transform:uppercase;color:var(--accent);margin-bottom:14px}
+  .muted{color:var(--muted)}
+  .grad{background:var(--grad);-webkit-background-clip:text;background-clip:text;color:transparent}
+
+  /* nav */
+  header.nav{position:sticky;top:0;z-index:50;backdrop-filter:blur(12px);
+    background:color-mix(in srgb,var(--bg) 80%,transparent);border-bottom:1px solid var(--line)}
+  .nav .wrap{display:flex;align-items:center;gap:20px;padding-top:14px;padding-bottom:14px}
+  .brand{font-weight:800;letter-spacing:-.02em;display:flex;align-items:center;gap:10px}
+  .brand .dot{width:12px;height:12px;border-radius:50%;background:var(--grad);box-shadow:0 0 16px var(--accent)}
+  .nav nav{margin-left:auto;display:flex;gap:22px}
+  .nav nav a{color:var(--muted);font-size:14px}
+  .nav nav a:hover{color:var(--text);text-decoration:none}
+  .iconbtn{background:var(--card);border:1px solid var(--line);color:var(--text);
+    width:38px;height:38px;border-radius:10px;cursor:pointer;font-size:16px;display:grid;place-items:center}
+  .iconbtn:hover{border-color:var(--accent)}
+  @media(max-width:720px){.nav nav{display:none}}
+
+  /* hero */
+  .hero{position:relative;padding:96px 0 84px;overflow:hidden}
+  .hero::before{content:"";position:absolute;inset:-40% -10% auto;height:640px;
+    background:radial-gradient(60% 60% at 30% 20%,rgba(94,234,212,.16),transparent 60%),
+               radial-gradient(50% 50% at 80% 10%,rgba(129,140,248,.18),transparent 60%);
+    filter:blur(6px);z-index:0;pointer-events:none}
+  .hero .wrap{position:relative;z-index:1}
+  .hero h1{font-size:clamp(38px,7vw,68px);font-weight:850}
+  .hero p.lead{font-size:clamp(17px,2.4vw,21px);color:var(--muted);max-width:620px;margin:.4em 0 0}
+  .badge{display:inline-flex;align-items:center;gap:8px;padding:6px 14px;border:1px solid var(--line);
+    border-radius:999px;background:var(--card);font-size:13px;color:var(--muted);margin-bottom:22px}
+  .badge b{color:var(--accent)}
+  .cta{display:flex;flex-wrap:wrap;gap:12px;margin-top:30px}
+  .btn{display:inline-flex;align-items:center;gap:8px;padding:12px 20px;border-radius:12px;font-weight:600;
+    border:1px solid var(--line);background:var(--card);color:var(--text);cursor:pointer;font-size:15px}
+  .btn:hover{text-decoration:none;border-color:var(--accent);transform:translateY(-1px);transition:.15s}
+  .btn.primary{background:var(--grad);color:#06121a;border:none}
+  .btn.primary:hover{opacity:.94}
+  .stats{display:flex;flex-wrap:wrap;gap:14px;margin-top:44px}
+  .stat{flex:1;min-width:150px;background:var(--card);border:1px solid var(--line);border-radius:var(--radius);padding:20px 22px}
+  .stat .n{font-size:30px;font-weight:800;letter-spacing:-.03em}
+  .stat .l{color:var(--muted);font-size:13px;margin-top:2px}
+
+  /* generic card */
+  .card{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);padding:24px;box-shadow:var(--shadow)}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:20px}
+  @media(max-width:760px){.grid2{grid-template-columns:1fr}}
+
+  /* demo */
+  .demo-head{display:flex;align-items:center;gap:10px;margin-bottom:6px}
+  .pill{font:600 11px/1 ui-monospace,monospace;letter-spacing:.1em;text-transform:uppercase;
+    padding:5px 9px;border-radius:7px;background:var(--card-2);border:1px solid var(--line);color:var(--muted)}
+  textarea,input[type=text]{width:100%;background:var(--bg-soft);border:1px solid var(--line);color:var(--text);
+    border-radius:10px;padding:12px 14px;font:inherit;resize:vertical}
+  textarea:focus,input:focus{outline:2px solid var(--accent);outline-offset:1px}
+  .row{display:flex;gap:10px;margin-top:12px;flex-wrap:wrap}
+  .out{margin-top:16px;min-height:24px;font-size:15px}
+  .bar{height:10px;border-radius:6px;background:var(--card-2);overflow:hidden;margin-top:6px}
+  .bar > i{display:block;height:100%;background:var(--grad)}
+  .resultline{display:flex;justify-content:space-between;gap:12px;padding:6px 0;border-bottom:1px dashed var(--line)}
+  .resultline b{font-variant-numeric:tabular-nums}
+  .drop{border:1.5px dashed var(--line);border-radius:12px;padding:26px;text-align:center;color:var(--muted);cursor:pointer;background:var(--bg-soft)}
+  .drop.hover{border-color:var(--accent);color:var(--text)}
+  .drop img{max-width:100%;max-height:220px;border-radius:10px;margin-top:12px}
+  .note{font-size:13px;color:var(--muted)}
+  .tag-pos{color:var(--pos);font-weight:700}
+  .tag-neg{color:var(--neg);font-weight:700}
+
+  /* chat */
+  .chat{display:none;margin-top:20px}
+  .chat.on{display:block}
+  .log{background:var(--bg-soft);border:1px solid var(--line);border-radius:12px;padding:14px;height:300px;overflow:auto;font-size:15px}
+  .msg{padding:8px 12px;border-radius:10px;margin:8px 0;max-width:85%;white-space:pre-wrap;word-wrap:break-word}
+  .msg.user{background:var(--accent-2);color:#fff;margin-left:auto}
+  .msg.bot{background:var(--card-2);border:1px solid var(--line)}
+  .msg.sys{background:transparent;color:var(--muted);font-size:13px;text-align:center;max-width:100%}
+  select{background:var(--bg-soft);border:1px solid var(--line);color:var(--text);border-radius:10px;padding:10px;font:inherit}
+
+  /* events + resources */
+  .evt{display:flex;gap:16px;align-items:baseline;padding:14px 0;border-bottom:1px solid var(--line)}
+  .evt .date{font:700 13px/1.2 ui-monospace,monospace;color:var(--accent);min-width:78px}
+  .evt .t{font-weight:600}
+  .reslist{columns:2;column-gap:32px}
+  @media(max-width:640px){.reslist{columns:1}}
+  .reslist h3{margin-top:18px;font-size:15px;color:var(--accent);break-after:avoid}
+  .reslist ul{margin:0 0 8px;padding-left:18px}
+  .reslist li{margin:5px 0;break-inside:avoid}
+
+  footer{padding:48px 0;border-top:1px solid var(--line);color:var(--muted);font-size:14px}
+  footer .wrap{display:flex;flex-wrap:wrap;gap:16px;align-items:center;justify-content:space-between}
+</style>
+</head>
+<body>
+
+<header class="nav">
+  <div class="wrap">
+    <span class="brand"><span class="dot"></span>Deep Learning RTP</span>
+    <nav>
+      <a href="#playground">Playground</a>
+      <a href="#about">About</a>
+      <a href="#events">Events</a>
+      <a href="#resources">Resources</a>
+    </nav>
+    <button class="iconbtn" id="theme-toggle" title="Toggle light/dark" aria-label="Toggle color theme">◐</button>
+  </div>
+</header>
+
+<div class="hero">
+  <div class="wrap">
+    <span class="badge">📍 Research Triangle Park, NC · <b>weekly, hybrid</b></span>
+    <h1>We <span class="grad">understand and build</span><br>neural networks.</h1>
+    <p class="lead">A study group for anyone who wants to go deep on deep learning. Every week: a paper review or a technical deep dive. All experience levels welcome.</p>
+    <div class="cta">
+      <a class="btn primary" href="https://www.meetup.com/deep-learning-rtp/" target="_blank" rel="noopener">Join on Meetup →</a>
+      <a class="btn" href="#playground">Run a model in your browser ↓</a>
+    </div>
+    <div class="stats">
+      <div class="stat"><div class="n">1,592</div><div class="l">members</div></div>
+      <div class="stat"><div class="n">402</div><div class="l">sessions run</div></div>
+      <div class="stat"><div class="n">4.9★</div><div class="l">from 323 ratings</div></div>
+      <div class="stat"><div class="n">Wed</div><div class="l">noon–2pm, every week</div></div>
+    </div>
+  </div>
+</div>
+
+<section id="playground">
+  <div class="wrap">
+    <div class="eyebrow">Live demo · nothing leaves your device</div>
+    <h2>Machine learning, running <span class="grad">in this tab</span>.</h2>
+    <p class="muted" style="max-width:660px">No server. No API keys. No uploads. The models below download to your browser and run on your own CPU/GPU — the same client-side inference the group digs into on Wednesdays. Click a demo to load it (first run fetches the model).</p>
+
+    <div class="grid2" style="margin-top:26px">
+      <!-- Sentiment -->
+      <div class="card">
+        <div class="demo-head"><span class="pill">Transformers.js</span><span class="note">DistilBERT · ~65MB</span></div>
+        <h3>Sentiment analysis</h3>
+        <textarea id="sent-in" rows="3" placeholder="Type a sentence…">Wednesday's paper review completely clicked for me.</textarea>
+        <div class="row"><button class="btn primary" id="sent-run">Analyze</button></div>
+        <div class="out" id="sent-out"></div>
+      </div>
+
+      <!-- Image classification -->
+      <div class="card">
+        <div class="demo-head"><span class="pill">Transformers.js</span><span class="note">ViT · ~90MB</span></div>
+        <h3>Image classification</h3>
+        <div class="drop" id="img-drop">
+          <span>Drop an image or click to upload</span>
+          <input type="file" id="img-file" accept="image/*" hidden>
+        </div>
+        <div class="out" id="img-out"></div>
+      </div>
+    </div>
+
+    <!-- LLM chat -->
+    <div class="card" style="margin-top:20px">
+      <div class="demo-head"><span class="pill">WebLLM · WebGPU</span><span class="note">a full LLM, on your GPU</span></div>
+      <h3>Chat with a language model — 100% local</h3>
+      <p class="muted" id="llm-intro">Runs a small instruct model entirely on your machine via WebGPU. First launch downloads the weights (~400MB–900MB, then cached). Zero servers, zero API keys.</p>
+      <div class="row">
+        <select id="llm-model">
+          <option value="Qwen2.5-0.5B-Instruct-q4f16_1-MLC">Qwen2.5 0.5B · fastest (~400MB)</option>
+          <option value="Llama-3.2-1B-Instruct-q4f16_1-MLC">Llama 3.2 1B · smarter (~900MB)</option>
+        </select>
+        <button class="btn primary" id="llm-launch">Launch local LLM →</button>
+      </div>
+      <div id="llm-status" class="out"></div>
+      <div class="chat" id="llm-chat">
+        <div class="bar" id="llm-progress" style="display:none"><i style="width:0"></i></div>
+        <div class="log" id="llm-log"></div>
+        <div class="row">
+          <input type="text" id="llm-in" placeholder="Ask something…" style="flex:1">
+          <button class="btn primary" id="llm-send">Send</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="about">
+  <div class="wrap">
+    <div class="eyebrow">About</div>
+    <h2>A study group, not a lecture series.</h2>
+    <div class="grid2" style="margin-top:20px">
+      <div>
+        <p>Deep Learning RTP is for people who want to <b>understand and build</b> neural networks. Each weekly session is a paper review or a technical deep dive. Between sessions, work through a course or project at your own pace — then come to ask questions, answer them, or present what you've figured out.</p>
+        <p>All experience levels and professional backgrounds are welcome.</p>
+      </div>
+      <div class="card">
+        <div class="resultline"><span class="muted">When</span><b>Wednesdays, 12–2pm ET</b></div>
+        <div class="resultline"><span class="muted">Where</span><b>The Frontier, RTP + Zoom</b></div>
+        <div class="resultline"><span class="muted">Format</span><b>Hybrid, weekly</b></div>
+        <div class="resultline" style="border:none"><span class="muted">Cost</span><b>Free</b></div>
+        <div class="row"><a class="btn primary" href="https://www.meetup.com/deep-learning-rtp/" target="_blank" rel="noopener">RSVP on Meetup</a></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="events">
+  <div class="wrap">
+    <div class="eyebrow">Upcoming</div>
+    <h2>What we're covering next.</h2>
+    <p class="muted">A snapshot — the <a href="https://www.meetup.com/deep-learning-rtp/events/" target="_blank" rel="noopener">Meetup events page</a> always has the live schedule and RSVPs.</p>
+    <div style="margin-top:18px">
+      <div class="evt"><span class="date">JUL 15</span><span class="t">LLM Architecture in 2026 — the DeepSeek technical report</span></div>
+      <div class="evt"><span class="date">JUL 22</span><span class="t">Deep Learning RTP — topic TBD</span></div>
+      <div class="evt"><span class="date">JUL 29</span><span class="t">Agents — let's get this over with</span></div>
+      <div class="evt"><span class="date">AUG 05</span><span class="t">Deep Learning RTP — topic TBD</span></div>
+    </div>
+  </div>
+</section>
+
+<section id="resources">
+  <div class="wrap">
+    <div class="eyebrow">Learn</div>
+    <h2>Where to start.</h2>
+    <p class="muted">New to the field or filling gaps? These are the resources the group keeps coming back to.</p>
+    <div class="reslist" style="margin-top:18px">
+      <h3>Build intuition</h3>
+      <ul>
+        <li><a href="https://www.3blue1brown.com/topics/neural-networks" target="_blank" rel="noopener">3Blue1Brown — Neural Networks</a></li>
+        <li><a href="https://www.youtube.com/playlist?list=PLAqhIrjkxbuWI23v9cThsA9GvCAUhRvKZ" target="_blank" rel="noopener">Karpathy — Neural Networks: Zero to Hero</a></li>
+        <li><a href="http://neuralnetworksanddeeplearning.com/" target="_blank" rel="noopener">Nielsen — Neural Networks &amp; Deep Learning</a></li>
+      </ul>
+      <h3>Courses</h3>
+      <ul>
+        <li><a href="https://course.fast.ai/" target="_blank" rel="noopener">fast.ai — Practical Deep Learning</a></li>
+        <li><a href="http://introtodeeplearning.com/" target="_blank" rel="noopener">MIT 6.S191 — Intro to Deep Learning</a></li>
+        <li><a href="https://cs231n.github.io/" target="_blank" rel="noopener">Stanford CS231n — CNNs for Vision</a></li>
+        <li><a href="https://huggingface.co/learn" target="_blank" rel="noopener">Hugging Face — LLM &amp; ML courses</a></li>
+      </ul>
+      <h3>Go deeper</h3>
+      <ul>
+        <li><a href="https://www.deeplearningbook.org/" target="_blank" rel="noopener">Goodfellow et&nbsp;al. — Deep Learning</a></li>
+        <li><a href="https://hastie.su.domains/ElemStatLearn/" target="_blank" rel="noopener">Hastie et&nbsp;al. — Elements of Statistical Learning</a></li>
+        <li><a href="https://arxiv.org/list/cs.LG/recent" target="_blank" rel="noopener">arXiv cs.LG — latest papers</a></li>
+      </ul>
+      <h3>Run models yourself</h3>
+      <ul>
+        <li><a href="https://huggingface.co/docs/transformers.js" target="_blank" rel="noopener">Transformers.js — ML in the browser</a></li>
+        <li><a href="https://webllm.mlc.ai/" target="_blank" rel="noopener">WebLLM — LLMs on WebGPU</a></li>
+        <li><a href="https://pytorch.org/tutorials/" target="_blank" rel="noopener">PyTorch tutorials</a></li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section id="conduct">
+  <div class="wrap">
+    <div class="eyebrow">Code of conduct</div>
+    <h2>Be kind. Be open.</h2>
+    <p class="muted" style="max-width:720px">We follow the spirit of the <a href="https://www.recurse.com/code-of-conduct" target="_blank" rel="noopener">Recurse Center social rules</a>. Harassment isn't tolerated; organizers may take any action they deem appropriate. Deep Learning RTP is a fully open, public forum — assume no privacy, and please don't share confidential, proprietary, or sensitive material. The group isn't liable for content shared by individual members, visitors, or speakers.</p>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <span>© Deep Learning RTP · Research Triangle Park, NC</span>
+    <span>
+      <a href="https://www.meetup.com/deep-learning-rtp/" target="_blank" rel="noopener">Meetup</a> ·
+      <a href="https://github.com/DeepLearningRTP" target="_blank" rel="noopener">GitHub</a>
+    </span>
+  </div>
+</footer>
+
+<script type="module">
+const $ = s => document.querySelector(s);
+
+/* ---------- theme ---------- */
+// Dark is the brand default; light is opt-in via the toggle (remembered per visitor).
+document.documentElement.dataset.theme = localStorage.getItem('dlrtp-theme') || 'dark';
+$('#theme-toggle').onclick = () => {
+  const next = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+  document.documentElement.dataset.theme = next;
+  localStorage.setItem('dlrtp-theme', next);
+};
+
+/* ---------- Transformers.js (lazy) ---------- */
+// ponytail: model ids below are the only tuning knobs; swap for other ONNX-ported HF models.
+let _tf;
+const transformers = () => (_tf ??= import('https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0'));
+
+// sentiment
+let _sent;
+const getSentiment = async () => {
+  const { pipeline } = await transformers();
+  return (_sent ??= pipeline('sentiment-analysis', 'Xenova/distilbert-base-uncased-finetuned-sst-2-english'));
+};
+$('#sent-run').onclick = async () => {
+  const text = $('#sent-in').value.trim();
+  const out = $('#sent-out');
+  if (!text) { out.textContent = 'Type something first.'; return; }
+  out.textContent = 'Loading model & running…';
+  try {
+    const [r] = await (await getSentiment())(text);
+    const pct = (r.score * 100).toFixed(1);
+    const cls = r.label === 'POSITIVE' ? 'tag-pos' : 'tag-neg';
+    out.innerHTML = `<span class="${cls}">${r.label}</span> · ${pct}%
+      <div class="bar"><i style="width:${pct}%"></i></div>`;
+  } catch (e) { out.textContent = 'Error: ' + e.message; }
+};
+
+// image classification
+let _img;
+const getImageClf = async () => {
+  const { pipeline } = await transformers();
+  return (_img ??= pipeline('image-classification', 'Xenova/vit-base-patch16-224'));
+};
+const drop = $('#img-drop'), file = $('#img-file'), imgOut = $('#img-out');
+drop.onclick = () => file.click();
+['dragover','dragenter'].forEach(ev => drop.addEventListener(ev, e => { e.preventDefault(); drop.classList.add('hover'); }));
+['dragleave','drop'].forEach(ev => drop.addEventListener(ev, e => { e.preventDefault(); drop.classList.remove('hover'); }));
+drop.addEventListener('drop', e => { if (e.dataTransfer.files[0]) classify(e.dataTransfer.files[0]); });
+file.onchange = () => file.files[0] && classify(file.files[0]);
+async function classify(f) {
+  const url = URL.createObjectURL(f);
+  drop.innerHTML = `<span>Change image</span><img src="${url}" alt="uploaded preview">`;
+  imgOut.textContent = 'Loading model & running…';
+  try {
+    const results = await (await getImageClf())(url, { topk: 4 });
+    imgOut.innerHTML = results.map(r =>
+      `<div class="resultline"><span>${r.label}</span><b>${(r.score*100).toFixed(1)}%</b></div>`).join('');
+  } catch (e) { imgOut.textContent = 'Error: ' + e.message; }
+}
+
+/* ---------- WebLLM (lazy, WebGPU-gated) ---------- */
+let engine, history = [];
+const status = $('#llm-status'), chat = $('#llm-chat'), log = $('#llm-log'),
+      prog = $('#llm-progress'), progBar = prog.querySelector('i');
+
+function addMsg(cls, text) {
+  const d = document.createElement('div');
+  d.className = 'msg ' + cls; d.textContent = text;
+  log.appendChild(d); log.scrollTop = log.scrollHeight;
+  return d;
+}
+
+$('#llm-launch').onclick = async () => {
+  if (!navigator.gpu) {
+    status.innerHTML = `<span class="tag-neg">WebGPU not available.</span> This demo needs Chrome, Edge, or Safari 26+ (Firefox: enable <code>dom.webgpu.enabled</code>). The two demos above still work everywhere.`;
+    return;
+  }
+  const modelId = $('#llm-model').value; // ponytail: default model = fastest small instruct; swap freely.
+  $('#llm-launch').disabled = true;
+  status.textContent = '';
+  chat.classList.add('on');
+  prog.style.display = 'block';
+  addMsg('sys', 'Downloading & compiling the model — first time only, then it\'s cached.');
+  try {
+    const { CreateMLCEngine } = await import('https://esm.run/@mlc-ai/web-llm@0.2.84');
+    engine = await CreateMLCEngine(modelId, {
+      initProgressCallback: r => { progBar.style.width = Math.round((r.progress||0)*100) + '%'; }
+    });
+    prog.style.display = 'none';
+    addMsg('sys', 'Ready. Ask it anything.');
+  } catch (e) {
+    prog.style.display = 'none';
+    addMsg('sys', 'Failed to load: ' + e.message);
+    $('#llm-launch').disabled = false;
+  }
+};
+
+async function send() {
+  const input = $('#llm-in'), text = input.value.trim();
+  if (!text || !engine) return;
+  input.value = '';
+  addMsg('user', text);
+  history.push({ role: 'user', content: text });
+  const bot = addMsg('bot', '');
+  try {
+    const chunks = await engine.chat.completions.create({ messages: history, stream: true });
+    let reply = '';
+    for await (const c of chunks) {
+      reply += c.choices[0]?.delta?.content || '';
+      bot.textContent = reply; log.scrollTop = log.scrollHeight;
+    }
+    history.push({ role: 'assistant', content: reply });
+  } catch (e) { bot.textContent = 'Error: ' + e.message; }
+}
+$('#llm-send').onclick = send;
+$('#llm-in').addEventListener('keydown', e => { if (e.key === 'Enter') send(); });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Why
The live site (`deeplearningrtp.github.io`) is a ~9-year-stale Jekyll README — defunct meeting times/venues and several dead links, while the group is thriving (1,592 members, 402 sessions, 4.9★, weekly Wed noon–2pm hybrid).

## What
Replaces it with a single static `index.html` — no build step, no framework, no backend.

- **Fresh content** pulled from the [Meetup](https://www.meetup.com/deep-learning-rtp/): tagline, real stats, weekly hybrid format, upcoming events, refreshed learning-resource list, condensed code of conduct.
- **Modern dark "AI" aesthetic** with a remembered light-mode toggle. Responsive, `prefers-reduced-motion` aware.
- **In-browser ML playground** (fitting for the group — nothing leaves the visitor's device):
  - Sentiment analysis + image classification via **Transformers.js** (WASM/WebGPU, works everywhere).
  - Opt-in **local LLM chat** via **WebLLM** (WebGPU-gated, graceful fallback message otherwise).
- Libraries lazy-load from CDN only when a demo is clicked, so first paint ships zero ML code.
- Drops Jekyll (`.nojekyll`); `README.md` rewritten as a real repo readme.

## Verified
- Static check: every JS `#id` reference resolves; both CDN version pins present.
- Rendered headless (Chromium) in dark + light — layout correct, no console errors on load.
- Not exercised here (needs a real browser + network): live model download/inference — click through once on the deployed page to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)