### PR TITLE
Add Calendar nav link to the generated events pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,6 +186,7 @@
     <span class="name">Deep Learning RTP</span>
     <nav>
       <a href="#meetings">Meetings</a>
+      <a href="/events/">Calendar</a>
       <a href="#about">About</a>
       <a href="#resources">Resources</a>
       <a href="#demos">Demos</a>


### PR DESCRIPTION
Adds one nav item, **Calendar → /events/**, pointing at the pages the dlrtp-ops repo now auto-publishes here (upcoming events, session archive, "Elsewhere in the Triangle" radar, and the subscribable dlrtp.ics feed). Those pages went live today but nothing linked to them.

Label is "Calendar" rather than "Events" to avoid clashing with the existing in-page "Meetings" anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)