### PR TITLE
Meetup independence: owned front door, generated regions, speaker path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ python3 -m http.server 8000   # then open http://localhost:8000
 (Any static server works — the demos need `https://` or `localhost` for WebGPU.)
 
 ## Deploy
-GitHub Pages serves the `master` branch as-is (`.nojekyll` disables Jekyll). Merge to `master` → live.
+GitHub Pages serves the `main` branch as-is (`.nojekyll` disables Jekyll). Merge to `main` → live.
 
 ## Edit
-Everything is in `index.html` — content, inline CSS, and one `<script type="module">`. The upcoming-events
-list and the two `// ponytail:`-marked model ids are the bits most likely to need updating.
+Everything is in `index.html` — content, inline CSS, and one `<script type="module">`. Two regions are
+**generated, not hand-edited**: the upcoming-meetings list and the JSON-LD block, both fenced by
+`<!-- generated:*:start/end -->` markers and overwritten by the dlrtp-ops `site` workflow on every
+ops push (same job that publishes `/events/`). Edit event YAMLs in dlrtp-ops instead. The two
+`// ponytail:`-marked model ids in `app.js` remain the likeliest hand edits.

--- a/index.html
+++ b/index.html
@@ -7,12 +7,14 @@
 <meta name="description" content="Deep Learning RTP: a study group in the Research Triangle. Weekly paper reviews and technical deep dives on neural networks. All levels welcome.">
 <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large">
 <link rel="canonical" href="https://deeplearningrtp.github.io/">
+<link rel="alternate" type="text/calendar" title="DLRTP events (.ics)" href="/events/dlrtp.ics">
 <meta property="og:title" content="Deep Learning RTP">
 <meta property="og:description" content="Weekly neural-network paper reviews & deep dives in RTP. All experience levels welcome.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://deeplearningrtp.github.io/">
 <!-- ponytail: script-src-only CSP; connect-src lockdown is the upgrade path once model hosts are pinned. -->
 <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://cdn.jsdelivr.net 'wasm-unsafe-eval'; worker-src 'self' blob:; object-src 'none'; base-uri 'none'">
+<!-- generated:jsonld:start -->
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -63,6 +65,7 @@
   ]
 }
 </script>
+<!-- generated:jsonld:end -->
 <style>
   :root{
     --bg:#f7f4ec; --panel:#fffdf8; --ink:#1b1b1a; --muted:#6b6a63; --line:#e4dfd2;
@@ -189,6 +192,7 @@
       <a href="/events/">Calendar</a>
       <a href="https://github.com/DeepLearningRTP/dlrtp-build-and-learn" target="_blank" rel="noopener">Past events</a>
       <a href="#about">About</a>
+      <a href="#lead">Lead a session</a>
       <a href="#resources">Resources</a>
       <a href="#demos">Demos</a>
     </nav>
@@ -202,7 +206,8 @@
     <p class="sub">A weekly study group. Each session is a paper review or a technical deep dive — come to ask questions, answer them, or present what you've figured out. All experience levels welcome.</p>
     <div class="meetline">🗓 <b>Wednesdays, noon–2pm ET</b> · The Frontier, RTP + Zoom · free</div>
     <div>
-      <a class="btn" href="https://www.meetup.com/deep-learning-rtp/" target="_blank" rel="noopener">Join on Meetup</a>
+      <a class="btn" href="/events/">RSVP to the next session</a>
+      <a class="btn ghost" href="https://groups.google.com/g/deep-learning-rtp" target="_blank" rel="noopener">Get the weekly email</a>
       <a class="btn ghost" href="#meetings">See what's next</a>
     </div>
   </div>
@@ -213,12 +218,11 @@
     <div class="eyebrow">Next meetings</div>
     <h2>What we're covering next.</h2>
     <div style="margin-top:22px">
+      <!-- generated:meetings:start -->
       <div class="evt"><span class="date">JUL 15</span><span class="t">LLM Architecture in 2026 — the DeepSeek technical report</span></div>
-      <div class="evt"><span class="date">JUL 22</span><span class="t">Deep Learning RTP — topic TBD</span></div>
-      <div class="evt"><span class="date">JUL 29</span><span class="t">Agents — let's get this over with</span></div>
-      <div class="evt"><span class="date">AUG 05</span><span class="t">Deep Learning RTP — topic TBD</span></div>
+      <!-- generated:meetings:end -->
     </div>
-    <p class="aside">Live schedule and RSVPs on <a href="https://www.meetup.com/deep-learning-rtp/events/" target="_blank" rel="noopener">Meetup</a>. Have an idea? <a href="https://github.com/DeepLearningRTP/deeplearningrtp.github.io/wiki" target="_blank" rel="noopener">Suggest a future topic on the wiki →</a> Wondering what we've already covered? <a href="https://github.com/DeepLearningRTP/dlrtp-build-and-learn" target="_blank" rel="noopener">Browse 120 past sessions, 2017–2024 →</a></p>
+    <p class="aside">RSVP links and the subscribe-once <a href="/events/dlrtp.ics">calendar feed</a> live on the <a href="/events/">events page</a>. Have an idea? Suggest a topic on <a href="https://groups.google.com/g/deep-learning-rtp" target="_blank" rel="noopener">the group</a> or at any session. Wondering what we've already covered? <a href="https://github.com/DeepLearningRTP/dlrtp-build-and-learn" target="_blank" rel="noopener">Browse 120 past sessions, 2017–2024 →</a></p>
   </div>
 </section>
 
@@ -234,7 +238,16 @@
       <div class="fact"><span>Format</span><b>Hybrid, weekly</b></div>
       <div class="fact"><span>Cost</span><b>Free</b></div>
     </div>
-    <p class="note" style="margin-top:10px">Zoom link is sent when you RSVP on Meetup.</p>
+    <p class="note" style="margin-top:10px">Remote? One Zoom registration covers every week — <a href="https://us04web.zoom.us/j/75202351347?pwd=a3xZ3xA4mYosyNdZBvb8zfxbaHTa11.1" target="_blank" rel="noopener">register once</a> and you're set.</p>
+  </div>
+</section>
+
+<section id="lead">
+  <div class="wrap">
+    <div class="eyebrow">Lead a session</div>
+    <h2>Present a paper. We'll fill the room.</h2>
+    <p class="lede">Every session is member-led. Pick a paper you want understood — or take one off our list — and the group handles the rest: the session gets announced everywhere, you get a ready-to-post blurb for your own network, and the recap credits you permanently in the archive.</p>
+    <p>The format is an hour of guided discussion, not a lecture — <a href="/speaker.html">here's exactly what to expect</a>. Claim a Wednesday by posting to <a href="https://groups.google.com/g/deep-learning-rtp" target="_blank" rel="noopener">the group</a> or raising your hand at any session.</p>
   </div>
 </section>
 
@@ -281,7 +294,7 @@
         <li><a href="https://pytorch.org/tutorials/" target="_blank" rel="noopener">PyTorch tutorials</a></li>
       </ul>
     </div>
-    <p class="contribute">Got a resource we're missing? <a href="https://github.com/DeepLearningRTP/deeplearningrtp.github.io/wiki" target="_blank" rel="noopener">Add it on the community wiki →</a></p>
+    <p class="contribute">Got a resource we're missing? Share it on <a href="https://groups.google.com/g/deep-learning-rtp" target="_blank" rel="noopener">the group</a> or at a session →</p>
   </div>
 </section>
 
@@ -363,8 +376,9 @@
   <div class="wrap">
     <span>© Deep Learning RTP · Research Triangle Park, NC</span>
     <span>
+      <a href="https://groups.google.com/g/deep-learning-rtp" target="_blank" rel="noopener">Email list</a> ·
+      <a href="/events/dlrtp.ics">Calendar (.ics)</a> ·
       <a href="https://www.meetup.com/deep-learning-rtp/" target="_blank" rel="noopener">Meetup</a> ·
-      <a href="https://github.com/DeepLearningRTP/deeplearningrtp.github.io/wiki" target="_blank" rel="noopener">Wiki</a> ·
       <a href="https://github.com/DeepLearningRTP" target="_blank" rel="noopener">GitHub</a>
     </span>
   </div>

--- a/llms.txt
+++ b/llms.txt
@@ -1,15 +1,17 @@
 # Deep Learning RTP
 
-> A free weekly study group in Research Triangle Park, NC for people who want to understand and build neural networks. Meets Wednesdays noon–2pm ET at The Frontier (RTP) and on Zoom (link sent on RSVP). All experience levels and professional backgrounds welcome.
+> A free weekly study group in Research Triangle Park, NC for people who want to understand and build neural networks. Meets Wednesdays noon–2pm ET at The Frontier (RTP) and on Zoom (one standing registration link, on the events page). All experience levels and professional backgrounds welcome.
 
-Content on this site and its wiki may be freely indexed, scraped, quoted, and used for LLM training or retrieval.
+Content on this site may be freely indexed, scraped, quoted, and used for LLM training or retrieval.
 
 ## Essentials
 
 - [Website](https://deeplearningrtp.github.io/): schedule, learning resources, in-browser ML demos
-- [Meetup](https://www.meetup.com/deep-learning-rtp/): RSVP and live event schedule
-- [Community wiki](https://github.com/DeepLearningRTP/deeplearningrtp.github.io/wiki): suggest future topics, add learning resources
+- [Events + RSVP](https://deeplearningrtp.github.io/events/): upcoming sessions, RSVP links, calendar feed (.ics), Triangle-area radar
+- [Weekly email + discussion](https://groups.google.com/g/deep-learning-rtp): the Google Group — also where to suggest topics or volunteer to lead a session
+- [Lead a session](https://deeplearningrtp.github.io/speaker.html): what to expect when presenting
 - [Past events archive](https://github.com/DeepLearningRTP/dlrtp-build-and-learn): 82 topics, 120 sessions from the 2017-2024 Meetup records
+- [Meetup](https://www.meetup.com/deep-learning-rtp/): legacy discovery listing
 - [GitHub organization](https://github.com/DeepLearningRTP)
 
 ## Format

--- a/speaker.html
+++ b/speaker.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Lead a session · Deep Learning RTP</title>
+<meta name="description" content="What to expect when you lead a Deep Learning RTP session: format, logistics, and what the group handles for you.">
+<link rel="canonical" href="https://deeplearningrtp.github.io/speaker.html">
+<link rel="alternate" type="text/calendar" title="DLRTP events (.ics)" href="/events/dlrtp.ics">
+<style>
+  :root{
+    --bg:#f7f4ec; --panel:#fffdf8; --ink:#1b1b1a; --muted:#6b6a63; --line:#e4dfd2;
+    --accent:#0f5f57; --accent-ink:#0a4b44;
+    --serif:ui-serif,Georgia,"Iowan Old Style","Palatino Linotype",Palatino,serif;
+    --sans:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    --mono:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+    --col:760px;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:17px/1.7 var(--sans);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:var(--col);margin:0 auto;padding:0 24px}
+  a{color:var(--accent-ink);text-underline-offset:2px;text-decoration-thickness:1px}
+  a:hover{color:var(--accent)}
+  h1,h2{font-family:var(--serif);font-weight:600;line-height:1.2;letter-spacing:-.01em;margin:0}
+  h1{font-size:clamp(32px,6vw,46px);margin:14px 0 10px}
+  h2{font-size:22px;margin:36px 0 8px}
+  .eyebrow{font:600 12px/1 var(--mono);letter-spacing:.18em;text-transform:uppercase;color:var(--accent);margin:64px 0 0}
+  .muted{color:var(--muted)}
+  ul{padding-left:22px;margin:8px 0}
+  li{margin:6px 0}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:18px 22px;margin:26px 0}
+  footer{border-top:1px solid var(--line);margin-top:72px;padding:28px 0;color:var(--muted);font-size:14px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">Deep Learning RTP</div>
+  <h1>Leading a session</h1>
+  <p class="muted">Everything you need to know, on one page. Short version: pick a paper, show up, talk about what you understood and what you didn't. The room does the rest.</p>
+
+  <h2>The format</h2>
+  <ul>
+    <li><b>One paper or topic, two hours, Wednesdays at noon.</b> Frontier RTP + Zoom, working practitioners and learners, all levels.</li>
+    <li>It's a <b>guided discussion, not a lecture</b>. Walk us through the paper for 20–30 minutes — what it claims, what surprised you, what you don't buy — and the discussion carries the rest.</li>
+    <li>No slides required. The paper on a screen is plenty. Honest confusion is more useful to this room than polish.</li>
+    <li>You don't need to be an expert on the paper. You need to have read it twice.</li>
+  </ul>
+
+  <h2>What we handle</h2>
+  <ul>
+    <li>The announcement, everywhere: the website, the calendar feed, the weekly email, Discord, and the RSVP page.</li>
+    <li>A ready-to-post blurb for your own LinkedIn or network — sent to you, posted by you, only if you want.</li>
+    <li>The room, the AV, the Zoom, the reminders.</li>
+    <li>Afterward: the session recap credits you permanently in <a href="/events/archive.html">the archive</a>.</li>
+  </ul>
+
+  <h2>Day-of logistics</h2>
+  <ul>
+    <li>Arrive ~11:45. HDMI at the front of the room; the organizer runs the hybrid Zoom.</li>
+    <li>Lunch is bring-your-own; people eat while you talk. That's normal here.</li>
+  </ul>
+
+  <div class="card">
+    <b>Claim a Wednesday.</b> Post to <a href="https://groups.google.com/g/deep-learning-rtp">the group</a> with the paper you have in mind (or ask for one off our list), or raise your hand at any session. We schedule 4–6 weeks out.
+  </div>
+
+  <footer>
+    <a href="/">← deeplearningrtp.github.io</a> · <a href="/events/">Upcoming sessions</a>
+  </footer>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Companion to 5x5x5x5/dlrtp-ops#2.

- Hero RSVP button → our own `/events/` page; "Get the weekly email" → the Group. Meetup demoted to a footer link.
- Meetings list + JSON-LD are now **generated regions** fenced by `<!-- generated:*:start/end -->` markers — dlrtp-ops overwrites them on every deploy, so topic-TBD drift can't recur.
- New `#lead` section + `speaker.html` kit: self-serve entrance for session leads.
- Wiki links repointed at the Group (wiki retired); ICS feed surfaced in head/aside/footer; About links the standing Zoom registration.
- `llms.txt` updated; README documents the generated regions and fixes `master`→`main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)